### PR TITLE
OrgFactory v2

### DIFF
--- a/src/OrgV1.sol
+++ b/src/OrgV1.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 interface IERC20 {
     function transfer(address recipient, uint256 amount) external returns (bool);
+    function approve(address spender, uint256 amount) external returns (bool);
 }
 
 interface ENS {

--- a/src/OrgV1.sol
+++ b/src/OrgV1.sol
@@ -6,12 +6,15 @@ interface IERC20 {
 }
 
 interface ENS {
-    function owner(bytes32 node) external view returns (address);
-    function resolver(bytes32 node) external view returns (address);
+    function owner(bytes32) external view returns (address);
+    function setOwner(bytes32, address) external;
+    function resolver(bytes32) external view returns (address);
+    function setSubnodeOwner(bytes32, bytes32, address) external returns (bytes32);
 }
 
 interface ReverseRegistrar {
     function setName(string memory name) external returns (bytes32);
+    function node(address addr) external view returns (bytes32);
 }
 
 /// A Radicle Org.

--- a/src/OrgV1.sol
+++ b/src/OrgV1.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 interface IERC20 {
     function transfer(address recipient, uint256 amount) external returns (bool);
+    function transferFrom(address spender, address recipient, uint256 amount) external returns (bool);
     function approve(address spender, uint256 amount) external returns (bool);
 }
 

--- a/src/OrgV1.t.sol
+++ b/src/OrgV1.t.sol
@@ -88,6 +88,13 @@ contract Token is IERC20 {
 
         return true;
     }
+
+    function approve(address spender, uint256 amount) override pure public returns (bool) {
+        spender;
+        amount;
+
+        return false;
+    }
 }
 
 function assertBytesEq(bytes memory a, bytes memory b) pure {

--- a/src/OrgV1.t.sol
+++ b/src/OrgV1.t.sol
@@ -81,9 +81,13 @@ contract Token is IERC20 {
     }
 
     function transfer(address addr, uint256 amount) override public returns (bool) {
-        require(balanceOf[msg.sender] >= amount);
+        return transferFrom(msg.sender, addr, amount);
+    }
 
-        balanceOf[msg.sender] -= amount;
+    function transferFrom(address spender, address addr, uint256 amount) override public returns (bool) {
+        require(balanceOf[spender] >= amount);
+
+        balanceOf[spender] -= amount;
         balanceOf[addr] += amount;
 
         return true;

--- a/src/OrgV2Factory.sol
+++ b/src/OrgV2Factory.sol
@@ -50,9 +50,6 @@ contract OrgV2Factory {
     /// An org was created. Includes the org and owner address as well as the name.
     event OrgCreated(address org, address safe, string domain);
 
-    /// An org was created. Includes the org and owner address.
-    event OrgCreated(address org, address safe);
-
     constructor(
         address _safeFactory,
         address _safeMasterCopy

--- a/src/OrgV2Factory.sol
+++ b/src/OrgV2Factory.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "./OrgV1.sol";
+
+interface SafeFactory {
+    function createProxy(address masterCopy, bytes memory data) external returns (Safe);
+}
+
+interface Resolver {
+    function multicall(bytes[] calldata data) external returns(bytes[] memory results);
+    function setAddr(bytes32, address) external;
+    function addr(bytes32 node) external returns (address);
+    function name(bytes32 node) external returns (string memory);
+}
+
+interface Registrar {
+    function commit(bytes32 commitment) external;
+    function register(string calldata name, address owner, uint256 salt) external;
+    function ens() external view returns (address);
+    function radNode() external view returns (bytes32);
+    function registrationFeeRad() external view returns (uint256);
+    function minCommitmentAge() external view returns (uint256);
+}
+
+interface Safe {
+    function setup(
+        address[] calldata _owners,
+        uint256 _threshold,
+        address to,
+        bytes calldata data,
+        address fallbackHandler,
+        address paymentToken,
+        uint256 payment,
+        address payable paymentReceiver
+    ) external;
+
+    function getThreshold() external returns (uint256);
+    function isOwner(address owner) external returns (bool);
+}
+
+/// Factory for orgs.
+contract OrgV2Factory {
+    SafeFactory immutable safeFactory;
+    address immutable safeMasterCopy;
+
+    // Radicle ENS domain.
+    string public radDomain = ".radicle.eth";
+
+    /// An org was created. Includes the org and owner address as well as the name.
+    event OrgCreated(address org, address safe, string domain);
+
+    /// An org was created. Includes the org and owner address.
+    event OrgCreated(address org, address safe);
+
+    constructor(
+        address _safeFactory,
+        address _safeMasterCopy
+    ) {
+        safeFactory = SafeFactory(_safeFactory);
+        safeMasterCopy = _safeMasterCopy;
+    }
+
+    /// Register a pre-committed name, create an org and associate the two
+    /// together.
+    ///
+    /// To use this method, one must commit to a name and use this contract's
+    /// address as the owner committed to. This method will transfer ownership
+    /// of the name to the given owner after completing the registration.
+    ///
+    /// To set additional ENS records for the given name, one may include
+    /// optional calldata using the `resolverData` parameter.
+    ///
+    /// @param owner The owner of the org.
+    /// @param name Name to register and associate with the org.
+    /// @param salt Commitment salt used in `commit` transaction.
+    /// @param resolverData Data payload for optional resolver multicall.
+    /// @param registrar Address of the Radicle registrar.
+    function registerAndCreateOrg(
+        address owner,
+        string memory name,
+        uint256 salt,
+        bytes[] calldata resolverData,
+        Registrar registrar
+    ) public returns (OrgV1, bytes32) {
+        // Temporarily set the owner of the name to this contract.
+        // It will be transfered to the given owner once the setup
+        // is complete.
+        registrar.register(name, address(this), salt);
+
+        ENS ens = ENS(registrar.ens());
+        bytes32 root = registrar.radNode();
+        bytes32 label = keccak256(bytes(name));
+
+        return setupOrg(
+            owner,
+            resolverData,
+            string(abi.encodePacked(name, radDomain)),
+            root,
+            label,
+            ens
+        );
+    }
+
+    /// Register a pre-committed name, create an org owned by multiple owners,
+    /// and associated the two together.
+    ///
+    /// @param owners The owners of the org.
+    /// @param threshold The minimum number of signatures to perform org transactions.
+    /// @param name Name to register and associate with the org.
+    /// @param salt Commitment salt used in `commit` transaction.
+    /// @param resolverData Data payload for optional resolver multicall.
+    /// @param registrar Address of the Radicle registrar.
+    function registerAndCreateOrg(
+        address[] memory owners,
+        uint256 threshold,
+        string memory name,
+        uint256 salt,
+        bytes[] calldata resolverData,
+        Registrar registrar
+    ) public returns (OrgV1, bytes32) {
+        registrar.register(name, address(this), salt);
+
+        ENS ens = ENS(registrar.ens());
+        bytes32 root = registrar.radNode();
+        bytes32 label = keccak256(bytes(name));
+
+        return setupOrg(
+            owners,
+            threshold,
+            resolverData,
+            string(abi.encodePacked(name, radDomain)),
+            root,
+            label,
+            ens
+        );
+    }
+
+    /// Setup an org with multiple owners.
+    function setupOrg(
+        address[] memory owners,
+        uint256 threshold,
+        bytes[] calldata resolverData,
+        string memory domain,
+        bytes32 parent,
+        bytes32 label,
+        ENS ens
+    ) private returns (OrgV1, bytes32) {
+        require(owners.length > 0, "OrgFactory: owners must not be empty");
+        require(threshold > 0, "OrgFactory: threshold must be greater than zero");
+        require(threshold <= owners.length, "OrgFactory: threshold must be lesser than or equal to owner count");
+
+        // Deploy safe.
+        Safe safe = safeFactory.createProxy(safeMasterCopy, new bytes(0));
+        safe.setup(owners, threshold, address(0), new bytes(0), address(0), address(0), 0, payable(address(0)));
+
+        return setupOrg(address(safe), resolverData, domain, parent, label, ens);
+    }
+
+    /// Setup an org with an existing owner.
+    function setupOrg(
+        address owner,
+        bytes[] calldata resolverData,
+        string memory domain,
+        bytes32 parent,
+        bytes32 label,
+        ENS ens
+    ) private returns (OrgV1, bytes32) {
+        // Create org, temporarily holding ownership.
+        OrgV1 org = new OrgV1(address(this));
+        // Get the ENS node for the name associated with this org.
+        bytes32 node = keccak256(abi.encodePacked(parent, label));
+        // Get the ENS resolver for the node.
+        Resolver resolver = Resolver(ens.resolver(node));
+        // Set the address of the ENS name to this org.
+        resolver.setAddr(node, address(org));
+        // Set any other ENS records.
+        resolver.multicall(resolverData);
+        // Set org ENS reverse-record.
+        org.setName(domain, ens);
+        // Transfer ownership of the org to the owner.
+        org.setOwner(owner);
+        // Transfer ownership of the name to the owner.
+        ens.setOwner(node, owner);
+
+        emit OrgCreated(address(org), owner, domain);
+
+        return (org, node);
+    }
+}

--- a/src/OrgV2Factory.sol
+++ b/src/OrgV2Factory.sol
@@ -83,6 +83,9 @@ contract OrgV2Factory {
         bytes[] calldata resolverData,
         Registrar registrar
     ) public returns (OrgV1, bytes32) {
+        require(address(registrar) != address(0), "OrgFactory: registrar must not be zero");
+        require(owner != address(0), "OrgFactory: owner must not be zero");
+
         // Temporarily set the owner of the name to this contract.
         // It will be transfered to the given owner once the setup
         // is complete.
@@ -119,6 +122,8 @@ contract OrgV2Factory {
         bytes[] calldata resolverData,
         Registrar registrar
     ) public returns (OrgV1, bytes32) {
+        require(address(registrar) != address(0), "OrgFactory: registrar must not be zero");
+
         registrar.register(name, address(this), salt);
 
         ENS ens = ENS(registrar.ens());
@@ -166,6 +171,8 @@ contract OrgV2Factory {
         bytes32 label,
         ENS ens
     ) private returns (OrgV1, bytes32) {
+        require(address(ens) != address(0), "OrgFactory: ENS address must not be zero");
+
         // Create org, temporarily holding ownership.
         OrgV1 org = new OrgV1(address(this));
         // Get the ENS node for the name associated with this org.

--- a/src/OrgV2Factory.t.sol
+++ b/src/OrgV2Factory.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "ds-test/test.sol";
+
+import "./OrgV2Factory.sol";
+import "./OrgV1.sol";
+
+interface Hevm {
+    function roll(uint256) external;
+    function store(address, bytes32, bytes32) external;
+}
+
+interface Token {
+    function approve(address spender, uint256 amount) external returns (bool);
+}
+
+contract OrgV2FactoryTest is DSTest {
+    address constant SAFE_FACTORY = 0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B;
+    address constant SAFE_MASTER_COPY = 0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F;
+    address constant RAD = 0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3;
+
+    Hevm hevm = Hevm(HEVM_ADDRESS);
+    OrgV2Factory factory;
+
+    function setUp() public {
+        factory = new OrgV2Factory(SAFE_FACTORY, SAFE_MASTER_COPY);
+
+        // Give this contract lots of $RAD.
+        hevm.store(
+            RAD,
+            keccak256(abi.encode(address(this), uint256(2))),
+            bytes32(uint(100_000_000e18))
+        );
+    }
+
+    function testRegisterAndCreateOrg() public {
+        Registrar registrar = Registrar(0x37723287Ae6F34866d82EE623401f92Ec9013154);
+        ENS ens = ENS(registrar.ens());
+
+        string memory name = "test-0r9481bv2lzka"; // Some random name.
+        uint256 salt = 42; // Commitment salt.
+
+        // Approve the registrar for spending the registration fee.
+        Token(RAD).approve(address(registrar), registrar.registrationFeeRad());
+
+        // Commit to a name.
+        {
+            address owner = address(factory);
+            bytes32 commitment = keccak256(abi.encodePacked(name, owner, salt));
+
+            registrar.commit(commitment);
+            hevm.roll(block.number + registrar.minCommitmentAge() + 1);
+        }
+
+        bytes[] memory data = new bytes[](0);
+
+        (OrgV1 org, bytes32 node) = factory.registerAndCreateOrg(
+            address(this), // This will be the final owner of the org.
+            name,
+            salt,
+            data,
+            registrar
+        );
+        assertTrue(address(org) != address(0));
+        assertEq(org.owner(), address(this));
+        assertEq(ens.owner(node), org.owner());
+
+        // Test ENS reverse record.
+        {
+            ReverseRegistrar reverse = ReverseRegistrar(ens.owner(org.ADDR_REVERSE_NODE()));
+            bytes32 orgNode = reverse.node(address(org));
+
+            Resolver resolver = Resolver(ens.resolver(orgNode));
+            assertEq(resolver.name(orgNode), string(abi.encodePacked(name, ".radicle.eth")));
+        }
+
+        // Test ENS forward record.
+        {
+            Resolver resolver = Resolver(ens.resolver(node));
+            assertEq(resolver.addr(node), address(org));
+        }
+    }
+
+    function testRegisterAndCreateOrgMultisig() public {
+        Registrar registrar = Registrar(0x37723287Ae6F34866d82EE623401f92Ec9013154);
+        ENS ens = ENS(registrar.ens());
+
+        string memory name = "test-8gajk2b108fs";
+        uint256 salt = 42; // Commitment salt.
+
+        // Approve the registrar for spending the registration fee.
+        Token(RAD).approve(address(registrar), registrar.registrationFeeRad());
+
+        // Commit to a name.
+        {
+            // The factory must be the initial owner of the name.
+            address owner = address(factory);
+            bytes32 commitment = keccak256(abi.encodePacked(name, owner, salt));
+
+            registrar.commit(commitment);
+            hevm.roll(block.number + registrar.minCommitmentAge() + 1);
+        }
+
+        address[] memory owners = new address[](1);
+        owners[0] = address(this);
+
+        bytes[] memory data = new bytes[](0);
+
+        (OrgV1 org, bytes32 node) = factory.registerAndCreateOrg(
+            owners,
+            1,
+            name,
+            salt,
+            data,
+            registrar
+        );
+        Safe safe = Safe(org.owner());
+
+        assertTrue(address(org) != address(0));
+        assertEq(ens.owner(node), org.owner());
+        assertEq(safe.getThreshold(), 1, "Threshold should be 1");
+        assertTrue(safe.isOwner(address(this)), "We must be an owner");
+    }
+}

--- a/src/OrgV2Factory.t.sol
+++ b/src/OrgV2Factory.t.sol
@@ -39,9 +39,12 @@ contract OrgV2FactoryTest is DSTest {
     function testRegisterReclaim() public {
         Registrar registrar = Registrar(0x37723287Ae6F34866d82EE623401f92Ec9013154);
         ENS ens = ENS(registrar.ens());
+        IERC20 rad = IERC20(RAD);
 
         string memory name = "test-0r94814bv2lzka"; // Some random name.
         uint256 salt = 42; // Commitment salt.
+
+        rad.approve(address(factory), registrar.registrationFeeRad());
 
         // Commit to a name.
         address owner = address(this);
@@ -89,6 +92,9 @@ contract OrgV2FactoryTest is DSTest {
 
         // Commit to a name.
         {
+            // Approve factory for fee.
+            IERC20(RAD).approve(address(factory), registrar.registrationFeeRad());
+
             address owner = address(this);
             // The factory must be the initial owner of the name.
             bytes32 commitment = keccak256(abi.encodePacked(name, address(factory), salt));
@@ -140,6 +146,9 @@ contract OrgV2FactoryTest is DSTest {
 
         // Commit to a name.
         {
+            // Approve factory for fee.
+            IERC20(RAD).approve(address(factory), registrar.registrationFeeRad());
+
             // The factory must be the initial owner of the name.
             bytes32 commitment = keccak256(abi.encodePacked(name, address(factory), salt));
             bytes32 ownerDigest = keccak256(abi.encodePacked(owners, salt));


### PR DESCRIPTION
A new org factory that enables setup of orgs with ENS records in only two transactions, instead of five.

The steps that are combined into a single transaction that were previously multiple transactions are:
1. Create org
2. Register name
3. Set forward ENS record
4. Set reverse ENS record

The step that is still separate (and has to be) is the `commit` that happens before name registration.